### PR TITLE
Upgrade oss-parent 0.0.2 -> 0.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 
     <properties>
         <version.immutables>2.8.3</version.immutables>
+        <version.jooq>3.12.1</version.jooq>
     </properties>
 
     <dependencyManagement>
@@ -263,7 +264,7 @@
                             <forcedTypes>
                                 <forcedType>
                                     <userType>Long[]</userType>
-                                    <expression>.*\.RELATEDFOOIDS</expression>
+                                    <includeExpression>.*\.RELATEDFOOIDS</includeExpression>
                                     <converter>org.jooq.Converter.ofNullable(Object[].class, Long[].class, i -&gt; (Long[])i, i -&gt; i)</converter>
                                 </forcedType>
                             </forcedTypes>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tech.picnic</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>0.0.2</version>
+        <version>0.0.3</version>
     </parent>
 
     <groupId>tech.picnic.jolo</groupId>
@@ -72,7 +72,6 @@
 
     <properties>
         <version.immutables>2.8.3</version.immutables>
-        <version.jooq>3.12.1</version.jooq>
     </properties>
 
     <dependencyManagement>

--- a/src/test/java/tech/picnic/jolo/UtilTest.java
+++ b/src/test/java/tech/picnic/jolo/UtilTest.java
@@ -23,14 +23,14 @@ public final class UtilTest {
   public void testEqualsOnFields() {
     Field<Long> withSchema = DSL.field(DSL.name("PUBLIC", "FOO", "ID"), Long.class);
     Field<Long> noSchema = DSL.field(DSL.name("FOO", "ID"), Long.class);
-    assertTrue(FOO.ID.equals(withSchema));
+    assertFalse(FOO.ID.equals(withSchema));
     assertFalse(withSchema.equals(FOO.ID));
     assertFalse(FOO.ID.equals(noSchema));
-    assertFalse(noSchema.equals(FOO.ID));
+    assertTrue(noSchema.equals(FOO.ID));
 
     // Also documenting this oddity: the qualified name of FOO.ID is not "PUBLIC.FOO.ID", even
     // though it is only considered equal to a field that has the "PUBLIC" qualifier.
-    assertEquals(FOO.ID.toString(), "\"PUBLIC\".\"FOO\".\"ID\"");
+    assertEquals(FOO.ID.toString(), "\"FOO\".\"ID\"");
     assertEquals(FOO.ID.getQualifiedName(), DSL.name("FOO", "ID"));
     assertEquals(withSchema.getQualifiedName(), DSL.name("PUBLIC", "FOO", "ID"));
     assertEquals(noSchema.getQualifiedName(), DSL.name("FOO", "ID"));


### PR DESCRIPTION
Property override can be removed with an upgrade to the latest oss-parent when https://github.com/PicnicSupermarket/oss-parent/pull/5 is merged. 