### PR TITLE
Fix Javadoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
                         code, so we must take care to exclude it during the
                         Javadoc generation process. Flag this issue with jOOQ
                         to get it resolved. -->
-                        <sourcepath>src/main/java</sourcepath>
+                        <sourcepath>${project.basedir}/src/main/java:${project.build.directory}/generated-sources/annotations</sourcepath>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
An earlier workaround for `jooq-codegen-maven` caused `maven-javadoc-plugin` to skip Immutables-generated code.

This fix can be tested by running the `javadoc:jar@generate-javadoc-jar` goal before and after the change.